### PR TITLE
Add Docker container configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3-slim
+
+RUN useradd -u 1000 -m zomboi
+USER zomboi
+WORKDIR /home/zomboi
+
+COPY --chown=zomboi:zomboi requirements.txt ./
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+COPY --chown=zomboi:zomboi . .
+COPY --chown=zomboi:zomboi docker_config.py config.py
+
+CMD [ "python", "zomboi.py" ]

--- a/README.md
+++ b/README.md
@@ -39,3 +39,21 @@ To run:
 
 It may be a good idea to run as a service, especially on a dedicated server
 
+## Docker
+
+You will have to mount the maps and logs directories of the Project Zomboid
+server into the zomboi container at the expected paths.
+
+To build and run zomboi in a Docker container:
+
+```
+docker build -t zomboi .
+docker run -d -v /path/to/maps:~/steam/steamapps/common/ProjectZomboid/media/maps -v /path/to/logs:~/Zomboid/Logs -e DISCORD_BOT_TOKEN=my_bot_token -e DISCORD_CHANNEL=channel_name_or_id -e SERVER_RCON_PASSWORD=my_rcon_password zomboi
+```
+
+Or using docker-compose:
+
+```
+docker-compose build
+docker-compose up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+
+services:
+  zomboi:
+    build: .
+    volumes:
+      - /path/to/maps:/home/zomboi/steam/steamapps/common/ProjectZomboid/media/maps
+      - /path/to/logs:/home/zomboi/Zomboid/Logs
+    environment:
+      DISCORD_BOT_TOKEN: "my_bot_token"
+      DISCORD_CHANNEL: "channel_name_or_id"
+      SERVER_RCON_PASSWORD: "my_rcon_password"
+    restart: unless-stopped

--- a/docker_config.py
+++ b/docker_config.py
@@ -1,0 +1,7 @@
+import os
+
+rconPassword = os.getenv('SERVER_RCON_PASSWORD')
+channel = os.getenv('DISCORD_CHANNEL')
+token = os.getenv('DISCORD_BOT_TOKEN')
+mapsPath = os.getenv('ZOMBOI_MAPS_PATH', '')
+logPath = os.getenv('ZOMBOI_LOG_PATH', '')


### PR DESCRIPTION
Created a basic Dockerfile and docker-compose configuration. The user
should only have to deal with mounting the logs and maps directories
into the container and specifying the token, channel and rcon password
using environment variables.

I created a separate configuration file that reads zomboi config values
from environment variables that is copied into the container. This
probably could be implemented more directly so a separate file is not
needed.