### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!requirements.txt
+!*.py


### PR DESCRIPTION
Prevents anything unnecessary from being copied to the container image
when building it.