### PR TITLE
add message when a user makes a new character

### DIFF
--- a/perks.py
+++ b/perks.py
@@ -18,6 +18,7 @@ class PerkHandler(commands.Cog):
         self.notifyJoin = os.getenv("JOINS", "True") == "True"
         self.notifyDeath = os.getenv("DEATHS", "True") == "True"
         self.notifyPerk = os.getenv("PERKS", "True") == "True"
+        self.notifyCreateChar = os.getenv("CREATECHAR", "True") == "True"
 
     def splitLine(self, line: str):
         """Split a log line into a timestamp and the remaining message"""
@@ -96,6 +97,12 @@ class PerkHandler(commands.Cog):
                 self.bot.log.info(f"{user.name} login")
                 if self.notifyJoin:
                     return f":zombie: {user.name} has arrived, survived for {user.hoursAlive} hours so far..."
+        elif "Created Player" in type:
+            if timestamp > self.lastUpdateTimestamp:
+                user.online = True
+                self.bot.log.info(f"{user.name} new character")
+                if self.notifyCreateChar:
+                    return f":person_raising_hand: {user.name} just woke up in the Apocalypse..."
         elif type == "Level Changed":
             match = re.search(r"\[(\w+)\]\[(\d+)\]", message)
             perk = match.group(1)

--- a/sample.env
+++ b/sample.env
@@ -15,6 +15,7 @@ JOINS=True
 DISCONNECTS=True
 DEATHS=True
 PERKS=True
+CREATECHAR=True
 
 # The password for rcon on the server (used to relay chat from discord to game)
 RCON_PASSWORD="password"


### PR DESCRIPTION
Checked the perks log and send a message when a user makes a new character. In response to [issue 28](https://github.com/JonnyPtn/zomboi/issues/28). Every time a character dies/respawns it disconnects/reconnects in users log, but the login notif is sent in perks.py and disconnect is sent in users.py (since they are diff log files). Don't think there was a bug with it, but rather a missing feature, though I could be wrong.