### PR TITLE
Support UTF-8 in chat messages

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -30,7 +30,7 @@ class ChatHandler(commands.Cog):
         """
         files = glob.glob(self.logPath + "/*chat.txt")
         if len(files) > 0:
-            with FileReadBackwards(files[0], encoding="latin-1") as f:
+            with FileReadBackwards(files[0], encoding="utf-8") as f:
                 newTimestamp = self.lastUpdateTimestamp
                 for line in f:
                     timestamp, message = self.splitLine(line)


### PR DESCRIPTION
# Changes
Setting encoding to utf-8 when reading chat logfile should resolve #61 and #57

# Testing
First message was sent with script set to `latin-1`, and second with `utf-8`. I haven't encountered any issues

In-game:
![Screenshot 2023-03-20 at 14 20 55](https://user-images.githubusercontent.com/2972266/226766833-bf58b48b-8b14-4833-abb2-ff882731f2d8.png)
Discord:
![Screenshot 2023-03-20 at 14 20 47](https://user-images.githubusercontent.com/2972266/226766849-b08e6081-cfa4-46af-84e3-654bac8e85c6.png)
