### PR TITLE
Use embeds for public logs (+ lint pass)

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -20,20 +20,24 @@ class AdminLogHandler(commands.Cog):
         self.sendLogs = os.getenv("ADMIN_LOGS", "True") == "True"
         # If the user has not enabled Admin logs, let's exit
         if not self.sendLogs:
-            return 
+            return
         self.adminChannel = os.getenv("ADMIN_CHANNEL")
         if not self.adminChannel:
-            self.bot.log.warning("Unable to get admin channel, setting to default channel...")
+            self.bot.log.warning(
+                "Unable to get admin channel, setting to default channel..."
+            )
             self.adminChannel = self.bot.channel.name
         if self.adminChannel.isdigit():
-            self.adminChannel = self.bot.get_channel(int(self.adminChannel))  # Find by id
+            self.adminChannel = self.bot.get_channel(
+                int(self.adminChannel)
+            )  # Find by id
         if isinstance(self.adminChannel, str):
             self.adminChannel = discord.utils.get(
                 self.bot.get_all_channels(), name=self.adminChannel
             )  # find by name
         self.update.start()
 
-    def splitLine(self, line: str):
+    def splitLine(self, line: str) -> tuple[datetime, str]:
         """Split a log line into a timestamp and the remaining message"""
         timestampStr, message = line.strip()[1:].split("]", 1)
         timestamp = datetime.strptime(timestampStr, "%d-%m-%y %H:%M:%S.%f")
@@ -42,7 +46,12 @@ class AdminLogHandler(commands.Cog):
     @tasks.loop(seconds=10)
     async def update(self):
         # Don't really know how performant this will be since it's opening 4 files -- set it to 10 seconds loop for now
-        files = glob.glob(self.logPath + "/*map.txt") + glob.glob(self.logPath + "/*cmd.txt") + glob.glob(self.logPath + "/*admin.txt") + glob.glob(self.logPath + "/*ClientActionLog.txt")
+        files = (
+            glob.glob(self.logPath + "/*map.txt")
+            + glob.glob(self.logPath + "/*cmd.txt")
+            + glob.glob(self.logPath + "/*admin.txt")
+            + glob.glob(self.logPath + "/*ClientActionLog.txt")
+        )
         if len(files) > 0:
             newTimestamps = []
             for file in files:
@@ -51,11 +60,10 @@ class AdminLogHandler(commands.Cog):
                         timestamp, message = self.splitLine(line)
                         if timestamp > self.lastUpdateTimestamp:
                             newTimestamps.append(timestamp)
-                            message = f'[{str(timestamp)}]: ' + message
+                            message = f"[{str(timestamp)}]: " + message
                             if message is not None and self.adminChannel is not None:
                                 await self.adminChannel.send(message)
                         else:
                             break
             if len(newTimestamps) > 0:
                 self.lastUpdateTimestamp = max(newTimestamps)
-        

--- a/chat.py
+++ b/chat.py
@@ -1,8 +1,11 @@
 from datetime import datetime
+from discord import Embed
 from discord.ext import tasks, commands
 from file_read_backwards import FileReadBackwards
 import glob
 import re
+
+import embed
 
 
 class ChatHandler(commands.Cog):
@@ -15,14 +18,14 @@ class ChatHandler(commands.Cog):
         self.update.start()
         self.webhook = None
 
-    def splitLine(self, line: str):
+    def splitLine(self, line: str) -> tuple[datetime, str]:
         """Split a log line into a timestamp and the remaining message"""
         timestampStr, message = line.strip()[1:].split("]", 1)
         timestamp = datetime.strptime(timestampStr, "%d-%m-%y %H:%M:%S.%f")
         return timestamp, message
 
     @tasks.loop(seconds=2)
-    async def update(self):
+    async def update(self) -> None:
         """Update the handler
 
         This will check the latest log file and update our data based on any
@@ -42,7 +45,7 @@ class ChatHandler(commands.Cog):
                         break
                 self.lastUpdateTimestamp = newTimestamp
 
-    async def handleLog(self, timestamp: datetime, message: str):
+    async def handleLog(self, timestamp: datetime, message: str) -> Embed | None:
         """Parse the given line from the logfile and mirror chat message in
         discord if necessary"""
 
@@ -53,6 +56,7 @@ class ChatHandler(commands.Cog):
         # Mirror any other received messages in the discord chat
         pattern = r"] Message.*author=\'(.*)\', text=\'(.*)\'"
         match = re.search(pattern, message)
+
         if match and self.bot.channel is not None:
             # Use a webhook to make it look like we're the discord member
             # God bless stack overflow
@@ -62,11 +66,15 @@ class ChatHandler(commands.Cog):
                         self.webhook = webhook
             if self.webhook is None:
                 self.webhook = await self.bot.channel.create_webhook(name="zomboi")
+
             name = match.group(1)
             avatar_url = None
             for member in self.bot.get_all_members():
                 if match.group(1) in member.name:
                     avatar_url = member.display_avatar
+
             await self.webhook.send(
-                match.group(2), username=name, avatar_url=avatar_url
+                embed=embed.chat_message(timestamp, message),
+                username=name,
+                avatar_url=avatar_url,
             )

--- a/embed.py
+++ b/embed.py
@@ -1,0 +1,43 @@
+from discord import Embed, Colour
+from datetime import datetime
+
+# Message formatting and coloring for public-facing logs
+
+
+def __embedify(timestamp: datetime, colour: Colour, message: str) -> Embed:
+    return Embed(timestamp=timestamp, colour=colour, description=message)
+
+
+def chat_message(timestamp: datetime, message: str) -> Embed:
+    """Stock blurple embed to relay a user's message"""
+    return __embedify(timestamp, Colour.og_blurple(), message)
+
+
+def perk(timestamp: datetime, user: str, aka: str, perk: str, level: int) -> Embed:
+    """Blue embed to indicate a user's level-up"""
+    message = f":chart_with_upwards_trend: {user} {aka}reached {perk} level {level}"
+    return __embedify(timestamp, Colour.blue(), message)
+
+
+def join(timestamp: datetime, user: str, aka: str) -> Embed:
+    """Green embed to indicate a new user/character joining"""
+    message = f":person_raising_hand: {user} {aka}just woke up in the Apocalypse..."
+    return __embedify(timestamp, Colour.green(), message)
+
+
+def resume(timestamp: datetime, user: str, aka: str, hours: int) -> Embed:
+    """Green embed to indicate a user/character resuming"""
+    message = f":person_doing_cartwheel: {user} {aka}has arrived, survived for {hours} hours so far..."
+    return __embedify(timestamp, Colour.green(), message)
+
+
+def leave(timestamp: datetime, user: str) -> Embed:
+    """Red embed to indicate a user disconnecting"""
+    message = f":person_running: {user} has left"
+    return __embedify(timestamp, Colour.red(), message)
+
+
+def death(timestamp: datetime, user: str, aka: str, hours: int) -> Embed:
+    """Dark embed to indicate a user's/character's death"""
+    message = f":zombie: {user} {aka}died after surviving {hours} hours :dizzy_face:"
+    return __embedify(timestamp, Colour.dark_red(), message)

--- a/maps.py
+++ b/maps.py
@@ -47,8 +47,14 @@ class MapHandler(commands.Cog):
                 if tryPath.exists():
                     self.mapsPath = str(tryPath)
                     break
-        if self.mapsPath is None or len(self.mapsPath) == 0 or not Path(self.mapsPath).is_dir():
-            self.bot.log.error(f"Map path {self.mapsPath} not found and/or no suitable default")
+        if (
+            self.mapsPath is None
+            or len(self.mapsPath) == 0
+            or not Path(self.mapsPath).is_dir()
+        ):
+            self.bot.log.error(
+                f"Map path {self.mapsPath} not found and/or no suitable default"
+            )
         else:
             self.bot.log.info(f"Maps path: {self.mapsPath}")
 

--- a/rcon_adapter.py
+++ b/rcon_adapter.py
@@ -5,12 +5,15 @@ from rcon.source import Client, rcon
 import re
 from datetime import datetime
 
+
 class RCONAdapter(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.rconHost = os.getenv("RCON_HOST") if os.getenv("RCON_HOST") else "localhost"
+        self.rconHost = (
+            os.getenv("RCON_HOST") if os.getenv("RCON_HOST") else "localhost"
+        )
         port = os.getenv("RCON_PORT")
-        if port is None:            
+        if port is None:
             self.rconPort = 27015
             self.bot.log.info("Using default port")
         else:
@@ -23,11 +26,15 @@ class RCONAdapter(commands.Cog):
     async def option(self, ctx, option: str, newValue: str = None):
         """Show or set the value of a server option"""
         if newValue is not None:
-            with Client(self.rconHost, self.rconPort, passwd=self.rconPassword, timeout=5.0) as client:
+            with Client(
+                self.rconHost, self.rconPort, passwd=self.rconPassword, timeout=5.0
+            ) as client:
                 result = client.run(f"changeoption {option} {newValue}")
             await ctx.send(f"`{result}`")
         else:
-            with Client(self.rconHost, self.rconPort, passwd=self.rconPassword, timeout=5.0) as client:
+            with Client(
+                self.rconHost, self.rconPort, passwd=self.rconPassword, timeout=5.0
+            ) as client:
                 message = client.run("showoptions")
             message = message.splitlines()
             regex = re.compile(f".*{option}.*", flags=re.IGNORECASE)
@@ -48,42 +55,52 @@ class RCONAdapter(commands.Cog):
         if name is None or skill is None or amount is None:
             await ctx.reply("requires three values: Name, skill and amount")
             return
-        with Client(self.rconHost, self.rconPort, passwd=self.rconPassword, timeout=5.0) as client:
-            result = client.run(f"addxp \"{name}\" {skill}={amount}")
+        with Client(
+            self.rconHost, self.rconPort, passwd=self.rconPassword, timeout=5.0
+        ) as client:
+            result = client.run(f'addxp "{name}" {skill}={amount}')
             await ctx.send(result)
 
     @tasks.loop(minutes=5)
     async def syncplayers(self):
         """Syncs online players by checking number with rcon"""
         if not self.rconPassword:
-            self.bot.log.warning('RCON password not set -- unable to syncplayers.')
+            self.bot.log.warning("RCON password not set -- unable to syncplayers.")
             self.update.stop()
             return
-        self.bot.log.info('Checking rcon to see if the player counter is correct')
+        self.bot.log.info("Checking rcon to see if the player counter is correct")
         try:
             response = await rcon(
-                'players',
-                host=self.rconHost, port=self.rconPort, passwd=self.rconPassword
+                "players",
+                host=self.rconHost,
+                port=self.rconPort,
+                passwd=self.rconPassword,
             )
         except Exception as e:
             self.bot.log.error(e)
-            self.bot.log.error('Unable to run players command on rcon -- check rcon options')
+            self.bot.log.error(
+                "Unable to run players command on rcon -- check rcon options"
+            )
             self.syncplayers.stop()
             return
 
         # remove first line from response
-        response = ''.join(response.splitlines(keepends=True)[1:])
+        response = "".join(response.splitlines(keepends=True)[1:])
 
         # update user info too
         userHandler = self.bot.get_cog("UserHandler")
         for user in userHandler.users.values():
             if user.name in response:
                 if user.online == False:
-                    self.bot.log.info(f'Player {user.name} out of sync, currently offline, should be online, fixing...')
+                    self.bot.log.info(
+                        f"Player {user.name} out of sync, currently offline, should be online, fixing..."
+                    )
                 user.lastSeen = datetime.now()
                 user.online = True
             else:
                 if user.online == True:
-                    self.bot.log.info(f'Player {user.name} out of sync, currently online, should be offline, fixing...')
+                    self.bot.log.info(
+                        f"Player {user.name} out of sync, currently online, should be offline, fixing..."
+                    )
                 user.online = False
-        self.bot.log.info('Synced players successfully!')
+        self.bot.log.info("Synced players successfully!")

--- a/users.py
+++ b/users.py
@@ -11,7 +11,10 @@ from typing import List
 from pathlib import Path
 import sqlite3
 
+import embed
+
 DISCORD_MAX_CHAR = 2000
+
 
 @dataclass
 class User:
@@ -41,33 +44,42 @@ class UserHandler(commands.Cog):
         self.onlineCount = None
         return
 
-    def getUser(self, name: str):
+    def getUser(self, name: str) -> User:
         """Get a user from a name, will create if it doesn't exist"""
         if not name in self.users:
             self.users[name] = User(name)
         return self.users[name]
 
-    def splitLine(self, line: str):
+    def splitLine(self, line: str) -> tuple[datetime, str]:
         """Split a log line into a timestamp and the remaining message"""
         timestampStr, message = line.strip()[1:].split("]", 1)
         timestamp = datetime.strptime(timestampStr, "%d-%m-%y %H:%M:%S.%f")
         return timestamp, message
 
-    def getCharName(self, name: str):
+    def getCharName(self, name: str) -> str:
         """Looks through the db file to find the name of the user's character"""
         # Needs to sleep to let database update after new character creation
         from time import sleep
+
         sleep(5)
         try:
-            playerdb = Path(os.getenv("SAVES_PATH")).joinpath("players.db") if os.getenv("SAVES_PATH") else Path.home().joinpath("Zomboid/Saves/Multiplayer/pzserver").joinpath("players.db")
+            playerdb = (
+                Path(os.getenv("SAVES_PATH")).joinpath("players.db")
+                if os.getenv("SAVES_PATH")
+                else Path.home()
+                .joinpath("Zomboid/Saves/Multiplayer/pzserver")
+                .joinpath("players.db")
+            )
             if not playerdb.is_file():
-                self.bot.log.error("Zomboid saves path was set incorrectly. Please check your environment variables")
-                return ''
+                self.bot.log.error(
+                    "Zomboid saves path was set incorrectly. Please check your environment variables"
+                )
+                return ""
             # Connect to the sqlite player db
             con = sqlite3.connect(str(playerdb))
             cur = con.cursor()
             # check the networkPlayers table
-            cur.execute('SELECT name FROM networkPlayers WHERE username = ?', [name])
+            cur.execute("SELECT name FROM networkPlayers WHERE username = ?", [name])
             charName = cur.fetchone()
             charName = charName[0] if charName else None
             con.close()
@@ -77,7 +89,7 @@ class UserHandler(commands.Cog):
         return charName
 
     @tasks.loop(seconds=2)
-    async def update(self):
+    async def update(self) -> None:
         """Update from the log file anything since the last update"""
         files = glob.glob(self.logPath + "/*user.txt")
         if len(files) > 0:
@@ -88,9 +100,9 @@ class UserHandler(commands.Cog):
                     if timestamp > newTimestamp:
                         newTimestamp = timestamp
                     if timestamp > self.lastUpdateTimestamp:
-                        message = self.handleLog(timestamp, message)
-                        if message is not None and self.bot.channel is not None:
-                            await self.bot.channel.send(message)
+                        embed = self.handleLog(timestamp, message)
+                        if embed is not None and self.bot.channel is not None:
+                            await self.bot.channel.send(embed=embed)
                     else:
                         break
                 self.lastUpdateTimestamp = newTimestamp
@@ -105,7 +117,7 @@ class UserHandler(commands.Cog):
             )
             self.onlineCount = onlineCount
 
-    def loadHistory(self):
+    def loadHistory(self) -> None:
         """Go through all log files and load the info"""
         self.bot.log.info("Loading user history...")
         files = glob.glob(self.logPath + "/**/*user.txt", recursive=True)
@@ -114,9 +126,10 @@ class UserHandler(commands.Cog):
             with open(file) as f:
                 for line in f:
                     self.handleLog(*self.splitLine(line))
+
         self.bot.log.info("User history loaded")
 
-    def handleLog(self, timestamp: datetime, message: str):
+    def handleLog(self, timestamp: datetime, message: str) -> discord.Embed | None:
         """Parse the log message and store any useful info. Returns a message string if relevant"""
 
         if "disconnected" in message:
@@ -130,7 +143,7 @@ class UserHandler(commands.Cog):
             if timestamp > self.lastUpdateTimestamp:
                 self.bot.log.info(f"{user.name} disconnected")
                 if self.notifyDisconnect:
-                    return f":person_running: {user.name} has left"
+                    return embed.leave(timestamp, user.name)
 
         elif "fully connected" in message:
             matches = re.search(r"\"(.*)\".*\((\d+),(\d+)", message)
@@ -158,7 +171,7 @@ class UserHandler(commands.Cog):
         headers = ["Name", "Online", "Last Seen", "Hours survived"]
         # if the number of users is over 28 (two messages), then only show online users
         num_users = len(self.users.values())
-        show_all = True if arg and arg.lower() == 'all' else False
+        show_all = True if arg and arg.lower() == "all" else False
         for user in self.users.values():
             if show_all or user.online:
                 table.append(
@@ -175,10 +188,15 @@ class UserHandler(commands.Cog):
         messages = [table]
         x = 0
         for message in messages:
-            while len(f'```\n{tabulate(messages[x], headers=headers, tablefmt="fancy_grid")}\n```') > DISCORD_MAX_CHAR:
+            while (
+                len(
+                    f'```\n{tabulate(messages[x], headers=headers, tablefmt="fancy_grid")}\n```'
+                )
+                > DISCORD_MAX_CHAR
+            ):
                 if x == len(messages) - 1:
                     messages.append([])
-                messages[x+1].append(messages[x][-1])
+                messages[x + 1].append(messages[x][-1])
                 messages[x] = messages[x][0:-1]
             await ctx.send(
                 f'```\n{tabulate(messages[x], headers=headers, tablefmt="fancy_grid")}\n```'

--- a/zomboi.py
+++ b/zomboi.py
@@ -57,7 +57,9 @@ zomboi.log.setLevel(logging.DEBUG)
 async def on_ready():
     zomboi.log.info(f"We have logged in as {zomboi.user}")
     channel = os.getenv("CHANNEL")
-    zomboi.channel = zomboi.get_channel(int(channel)) if channel.isdigit() else None  # Find by id
+    zomboi.channel = (  # Find by id
+        zomboi.get_channel(int(channel)) if channel.isdigit() else None
+    )
     if zomboi.channel is None:
         zomboi.channel = discord.utils.get(
             zomboi.get_all_channels(), name=channel


### PR DESCRIPTION
Using embeds for user logs adds a few nice things:

- Emojis are already used, but the sidebar colour can be used to give immediate context on the message at a glance
- Grants protection against users trying to ping roles/everyone/users from within the game (text within embeds is formatted but pings are not sent out)
- Abstracts message formatting and colouring into a smaller file
- Actually uses the "timestamp" parameter (which is likely unnecessary given Discord's own timestamps, but maybe the bot hitches on something and this should keep original timestamps intact.)

Additionally while looking through my linter formatted the files. I also added some type hints on the files I touched, but left the rest alone.